### PR TITLE
fix: remappings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,8 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-
+remappings = [
+  "@openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
+]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,0 @@
-ds-test/=lib/solmate/lib/ds-test/src/
-forge-std/=lib/forge-std/src/
-solmate/=lib/solmate/src/
-openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
-openzeppelin-contracts/=lib/openzeppelin-contracts/


### PR DESCRIPTION
Ref https://github.com/foundry-rs/foundry/discussions/4690

Now whenever you have an import that starts with `@openzeppelin-contracts-upgradeable/`, the solidity compiler will replace that part of the import path with `lib/openzeppelin-contracts-upgradeable/contracts/`